### PR TITLE
Add GitHub issue link filter

### DIFF
--- a/Rules
+++ b/Rules
@@ -8,6 +8,7 @@ end
 
 compile '/**/*.{html,md}' do
   filter :erb
+  filter :github_issues
   filter :kramdown, auto_ids: false if item.identifier =~ '/**/*.md'
   filter :colorize_syntax, :default_colorizer => :rouge
   layout '/default.*'

--- a/Rules
+++ b/Rules
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+ignore '/github/**/*'
+
 preprocess do
   hide_items_from_sitemap
 end

--- a/lib/github_issues_filter.rb
+++ b/lib/github_issues_filter.rb
@@ -1,0 +1,27 @@
+class GitHubIssuesFilter < Nanoc::Filter
+  identifier :github_issues
+  type :text
+
+  def run(content, params={})
+    liblcf_issues = @items.find_all('/github/liblcf/issues/*')
+    player_issues = @items.find_all('/github/player/issues/*')
+
+    content.scan(/player#\d+/).each { |x|
+      n = (x.match /\d+/)[0].to_i
+      issue = player_issues[n]
+      type = issue[:is_pr] ? "pulls" : "issues"
+      url = "https://github.com/EasyRPG/Player/#{type}/#{n}"
+      content = content.gsub(x, "[\##{n}](#{url} \"Player: #{issue[:title]}\")")
+    }
+
+    content.scan(/liblcf#\d+/).each { |x|
+      n = (x.match /\d+/)[0].to_i
+      issue = liblcf_issues[n]
+      type = issue[:is_pr] ? "pulls" : "issues"
+      url = "https://github.com/EasyRPG/liblcf/#{type}/#{n}"
+      content = content.gsub(x, "[\##{n}](#{url} \"liblcf: #{issue[:title]}\")")
+    }
+
+    content
+  end
+end

--- a/lib/github_liblcf_datasource.rb
+++ b/lib/github_liblcf_datasource.rb
@@ -1,0 +1,11 @@
+require 'json'
+
+class GithubLibLcfDataSource < Nanoc::DataSource
+  identifier :github_liblcf
+
+  def items
+    JSON.parse(open(".cache/liblcf_issues.json").read()).map do |x|
+      new_item(x["title"], x, "/liblcf/issues/#{x["number"]}")
+    end
+  end
+end

--- a/lib/github_player_datasource.rb
+++ b/lib/github_player_datasource.rb
@@ -1,0 +1,11 @@
+require 'json'
+
+class GithubPlayerDataSource < Nanoc::DataSource
+  identifier :github_player
+
+  def items
+    JSON.parse(open(".cache/player_issues.json").read()).map do |x|
+      new_item(x["title"], x, "/player/issues/#{x["number"]}")
+    end
+  end
+end

--- a/make_cache.rb
+++ b/make_cache.rb
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby
+
+require "json"
+require "open-uri"
+
+def fetch(repo)
+  i = 1
+  res = []
+
+  loop do
+    j = JSON.parse(URI.open("https://api.github.com/repos/easyrpg/#{repo}/issues?per_page=100&page=#{i}&filter=all&state=all&sort=created").read())
+    return res if j.length == 0
+    j.each { |item|
+      res.push({
+        title: item["title"],
+        number: item["number"],
+        is_pr: item.key?("pull_request")
+      })
+      puts item["title"]
+    }
+    i += 1
+  end
+end
+
+liblcf = fetch("liblcf")
+player = fetch("player")
+
+File.open(".cache/liblcf_issues.json", "w") do |f|
+  f.write(JSON.pretty_generate(liblcf))
+end
+
+File.open(".cache/player_issues.json", "w") do |f|
+  f.write(JSON.pretty_generate(player))
+end

--- a/make_cache.rb
+++ b/make_cache.rb
@@ -16,7 +16,6 @@ def fetch(repo)
         number: item["number"],
         is_pr: item.key?("pull_request")
       })
-      puts item["title"]
     }
     i += 1
   end

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -51,6 +51,12 @@ data_sources:
     # UTF-8 (which they should be!), change this.
     encoding: utf-8
 
+  - type: github_player
+    items_root: /github
+
+  - type: github_liblcf
+    items_root: /github
+
 # Configuration for the “check” command, which run unit tests on the site.
 checks:
   # Configuration for the “internal_links” checker, which checks whether all


### PR DESCRIPTION
Thats a bit rough for now, but it works ;). Please give feedback.

Converts stuff like ``player#1234`` to ``[#1234](https://github.com/EasyRPG/Player/pulls/1234 "Player: Save game and move route fixes")``

Workflow:

1. Create ``.cache``, then execute ``make_cache.rb`` (TODO: Add to Makefile)
2. ``make``

TODO:

- Unknown issue numbers will crash
- Will always emit markdown (is there a way to figure out the context (html or md) in filter?
- Code duplication


