### PR TITLE
Add liblcf to the Tools download page to avoid issues when trying to get code of LCF2XML and LCFSTRINGS

### DIFF
--- a/content/player/guide/game_translation.md
+++ b/content/player/guide/game_translation.md
@@ -99,7 +99,7 @@ These assets can also be translated. All you have to do is mirror the correspond
 
 For example, the translated version of ``Picture/Intro.png`` is located in ``Language/LANGUAGE_NAME/Picture/Intro.png``.
 
-EasyRPG Player already supports the display of many languages, but you can also use your own font. To do so, place the files ``Font.ttf`` or ``Font2.ttf`` in ``Language/LANGUAGE_NAME/Fonts`` (besides ``ttf``, other formats such as ``fon`` or ``bdf`` are also supported). Which of the two files is used depends on the font setting of the system graphic.
+EasyRPG Player already supports the display of many languages, but you can also use your own font. To do so, place the files ``Font.ttf`` or ``Font2.ttf`` in ``Language/LANGUAGE_NAME/Font`` (besides ``ttf``, other formats such as ``fon`` or ``bdf`` are also supported). Which of the two files is used depends on the font setting of the system graphic.
 
 If the game already provides custom fonts and they are unsuitable for your translation add ``Font=Builtin`` to the ``Meta.ini`` to force the usage of the font bundled with EasyRPG Player.
 

--- a/content/tools/downloads.md
+++ b/content/tools/downloads.md
@@ -24,10 +24,11 @@ state, but they might be unusable and not recommended for general use:
 #### Source code:
 
 *   Tools: [source snapshot].
+*   liblcf (library to handle RPG Maker 2000 and 2003 game data; LCF2XML and LCFSTRINGS codes are stored here): [liblcf source snapshot].
 
 ## Code repository
 
-The [Tools repository] is available at GitHub.
+The [Tools repository] and [liblcf repository] are available at GitHub.
 
 [LCF2XML]: <%= jenkins_link("liblcf-win32", "build/bin/lcf2xml.exe") %>
 [LCFSTRINGS]: <%= jenkins_link("liblcf-win32", "build/bin/lcfstrings.exe") %>
@@ -41,6 +42,8 @@ The [Tools repository] is available at GitHub.
 [XYZ Thumbnailer]: <%= jenkins_link("tools-win32", "bin/xyz-thumbnailer.zip") %>
 
 [source snapshot]: https://github.com/EasyRPG/Tools/archive/master.zip
+[liblcf source snapshot]: https://github.com/EasyRPG/liblcf/archive/master.zip
 [Tools repository]: https://github.com/EasyRPG/Tools
+[liblcf repository]: https://github.com/EasyRPG/liblcf
 
 </div>

--- a/content/tools/index.md
+++ b/content/tools/index.md
@@ -19,6 +19,9 @@ or providing information about them.
 ### LCF2XML
 Tool to convert LMU, LMT, LDB and LSD files into XML and vice-versa.
 
+### LCFSTRINGS
+Tool to list the strings used for the text and filenames from LMU, LMT, LDB and LSD files.
+
 ### LMU2PNG
 Tool to render LMU maps to PNG images with events as tiles support.
 


### PR DESCRIPTION
Some users complained that trying to compile LCF2XML, getting and checking its code was confusing from the download page of the tools on the website since only the Tools repository and its code are linked, while LCF2XML (and also LCFSTRINGS) is instead hosted in the liblcf repository (This is intended, see [liblcf issue 302](https://github.com/EasyRPG/liblcf/issues/302) for more details), which is confusing since not mentioned at all there. This pull request adds mentions of the liblcf repository, what it is shortly, specify where LCF2XML and LCFSTRINGS are hosted and adds links to them on the Tools download page.