### PR TITLE
Update the Player progress page on the website

### DIFF
--- a/content/player/progress.md
+++ b/content/player/progress.md
@@ -39,6 +39,7 @@ menu_weight: 4
 
 **Work in progress:**
 
+- Accurate RNG
 - Expanded support for currently supported RPG_RT patches
 - Expanded support for RPG Maker 2003 battle system
 - Movie playback

--- a/content/player/progress.md
+++ b/content/player/progress.md
@@ -8,40 +8,47 @@ menu_weight: 4
 
 **Already done:**
 
-- Battle animations
 - All event commands except movie playback
+- Audio panning
+- Battle animations
 - Built-in font for most languages
+- External font support
+- Full savegame compatibility with RPG_RT
+- Game controller/Joystick support
 - Games from any region run without additional configuration
 - Inelukis MP3 Patch
 - Interpreter quirks
-- Mouse/Touch support
+- Maniac patch
 - Map looping
 - Map rendering
 - Menus
-- Most load/save works
+- Mouse/Touch support
 - Move commands
 - PicPointerPatch
 - RPG Maker 2000 battle system
 - RPG Maker 2003 1.12 features (changed Picture behaviour)
 - RPG Maker 2003 battle system
 - Sound and Music output
+- Soundfont support
 - Support for all known RTPs
 - Support for game translations
 - Timers
 - Vehicles
 - Weather effects
-- External font support
-- Game controller/Joystick support
+- zip and lzh archives support
 
 **Work in progress:**
 
-- Full savegame compatibility with RPG_RT
-- Support for more RPG_RT patches
+- Expanded support for currently supported RPG_RT patches
+- Expanded support for RPG Maker 2003 battle system
+- Movie playback
 - Porting to new (and old!) platforms ;-)
+- Support for more RPG_RT patches
 
 **Still unimplemented:**
 
+- Dungeon generation support
 - Hardware acceleration
-- Movie playback
+
 
 </div>

--- a/content/player/progress.md
+++ b/content/player/progress.md
@@ -18,7 +18,6 @@ menu_weight: 4
 - Games from any region run without additional configuration
 - Inelukis MP3 Patch
 - Interpreter quirks
-- Maniac patch
 - Map looping
 - Map rendering
 - Menus
@@ -42,6 +41,8 @@ menu_weight: 4
 - Accurate RNG
 - Expanded support for currently supported RPG_RT patches
 - Expanded support for RPG Maker 2003 battle system
+- Hardware acceleration
+- [Many Maniac patch features](https://github.com/EasyRPG/Player/issues/1818)
 - Movie playback
 - Porting to new (and old!) platforms ;-)
 - Support for more RPG_RT patches
@@ -49,7 +50,6 @@ menu_weight: 4
 **Still unimplemented:**
 
 - Dungeon generation support
-- Hardware acceleration
 
 
 </div>


### PR DESCRIPTION
- Reorganise the list to be by alphabetical order (seems to have been the original intent)
- Add to the already done category `audio panning`, `Maniac patch`, `Soundfont support`, and `zip and lzh archives support`
- Move `Full savegame compatibility with RPG_RT` from the wip category to the already done category, and remove the `Most load/save works` (redundant)
- Add to the wip category `Accurate RNG`, `Expanded support for currently supported RPG_RT patches`, `Expanded support for RPG Maker 2003 battle system`
- Move `Movie playback` from the still unimplemented category to the wip category
- Add to the still unimplemented category `Dungeon generation support`

If there are things that should be added, moved, removed, etc. or that there are things needing changes, feel free to mention it or discuss it, as it is meant to be an overall progress of the project.